### PR TITLE
feat: initialize existing project

### DIFF
--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -64,6 +64,10 @@ func cmdInit() {
 		return
 	}
 
-	parser := gen.NewParser(dir, defaultModuleName, moduleName, folder.Folder)
+	parser, err := gen.NewParser(dir, defaultModuleName, moduleName, folder.Folder)
+	if err != nil {
+		fmt.Println("init: ", err)
+		return
+	}
 	parser.Parse()
 }


### PR DESCRIPTION
Go init
- return error if the folder is already a gofs project. doesn't overwrite
- only creates .gofs folder if a go module already exists in the dir